### PR TITLE
fix prompting superfluous header

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -318,9 +318,12 @@ func (e *Entry) writePublicResponse(w http.ResponseWriter) error {
 }
 
 func (e *Entry) writePrivateResponse(w http.ResponseWriter) error {
+	// wrap the original response writer
 	e.Response.SetBody(backends.WrapResponseWriterToBackend(w))
 	e.Response.WaitClose()
-	w.WriteHeader(e.Response.Code)
+	if !e.Response.IsFirstByteWritten {
+		w.WriteHeader(e.Response.Code)
+	}
 	return nil
 }
 

--- a/response.go
+++ b/response.go
@@ -26,8 +26,9 @@ type Response struct {
 	body       backends.Backend
 	snapHeader http.Header
 
-	wroteHeader  bool
-	bodyComplete bool
+	wroteHeader        bool
+	bodyComplete       bool
+	IsFirstByteWritten bool
 
 	bodyChan         chan struct{} // indicates whether the backend is set or not.
 	bodyCompleteChan chan struct{}
@@ -94,6 +95,9 @@ func (r *Response) Write(buf []byte) (int, error) {
 	}
 
 	if r.body != nil {
+		if !r.IsFirstByteWritten {
+			r.IsFirstByteWritten = true
+		}
 		return r.body.Write(buf)
 	}
 


### PR DESCRIPTION
# Purpose

For private response, we need to check whether the HTTP status code is written or not and then set it.