### PR TITLE
add HEAD process

### DIFF
--- a/cmd/Caddyfile
+++ b/cmd/Caddyfile
@@ -15,7 +15,7 @@
 
         cache_type in_memory
         match_path /
-        match_header Content-Type image/jpg image/png "text/plain; charset=utf-8"
+        match_header Content-Type image/jpg image/png "text/plain; charset=utf-8" "application/json" ""
 
     }
 

--- a/response.go
+++ b/response.go
@@ -14,7 +14,7 @@ import (
 func copyHeaders(from http.Header, to http.Header) {
 	for k, values := range from {
 		for _, v := range values {
-			to.Add(k, v)
+			to.Set(k, v)
 		}
 	}
 }


### PR DESCRIPTION
# Purpose

When receiving the http HEAD method, we don't need to trigger the writeBody function. This way, we can prevent some error happening.