### PR TITLE
fix README.md typo

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -15,7 +15,7 @@
 
   This is a http cache plugin for caddy 2. In fact, I am not so familiar with the part of cdn cache's mechanism so I reference the code from https://github.com/nicolasazrak/caddy-cache. which is the caddy v1's cache module. Then, I migrate the codebase to be consist with the caddy2 architecture and develop more features based on that.
 
-  Currently, this doesn't support =distributed cache= yet. It's still in plain.
+  Currently, this doesn't support =distributed cache= yet. It's still in plan.
 
 * Features
  


### PR DESCRIPTION
## Object

Correct the word from `plain` to `plan`

## Description
```
Currently, this doesn't support =distributed cache= yet. It's still in plain.
```
to
```
Currently, this doesn't support =distributed cache= yet. It's still in plan.
```