### PR TITLE
Fix 3xx responses from upstream

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -374,7 +374,7 @@ func (e *Entry) setBackend(ctx context.Context, config *Config) error {
 
 	switch config.Type {
 	case file:
-		backend, err = backends.NewFileBackend(config.Path)
+		backend, err = backends.NewFileBackend(config.Path, e.keyWithRespectVary())
 	case inMemory:
 		backend, err = backends.NewInMemoryBackend(ctx, e.keyWithRespectVary(), e.expiration)
 	case redis:

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -43,7 +43,7 @@ var (
 	defaultcacheBucketsNum        = 256
 	defaultCacheMaxMemorySize     = GB // default is 1 GB
 	defaultRedisConnectionSetting = "localhost:6379 0"
-	defaultCacheKeyTemplate       = "{http.request.method} {http.request.host}{http.request.uri.path}?{http.request.uri.query}"
+	defaultCacheKeyTemplate       = "{http.request.method} {http.request.host}{http.request.uri}"
 	// Note: prevent character space in the key
 	// the key is refereced from github.com/caddyserver/caddy/v2/modules/caddyhttp.addHTTPVarsToReplacer
 )

--- a/caddyfile_test.go
+++ b/caddyfile_test.go
@@ -22,7 +22,7 @@ func (suite *CaddyfileTestSuite) TestSettingFileCacheType() {
 			path /tmp/cache
 			default_max_age 5m
 			status_header "X-Cache-Status"
-			cache_key "{http.request.method} {http.request.host}{http.request.uri.path} {http.request.uri.query}"
+			cache_key "{http.request.method} {http.request.host}{http.request.uri}"
 			cache_bucket_num 1024
 			match_header Content-Type image/png
 			match_header X-Forwarded-For 144.30.20.10
@@ -55,7 +55,7 @@ func (suite *CaddyfileTestSuite) TestInvalidCacheStatusHeader() {
 	h := httpcaddyfile.Helper{
 		Dispenser: caddyfile.NewTestDispenser(`
 		http_cache {
-			status_header X-Cache-Status A-Status	
+			status_header X-Cache-Status A-Status
 		}`),
 	}
 	_, err := parseCaddyfile(h)

--- a/endpoint.go
+++ b/endpoint.go
@@ -230,10 +230,7 @@ func (c cachePurge) handlePurge(w http.ResponseWriter, r *http.Request) error {
 	purgeRepl.Set("http.request.uri.path", payload.path)
 
 	cache := getHandlerCache()
-	// example key should be like "GET localhost/static/js/chunk-element.js?"
-	i := strings.Index(config.CacheKeyTemplate, "?")
-	escapedKeyTmpl := config.CacheKeyTemplate[:i] + "\\" + config.CacheKeyTemplate[i:]
 
-	conds := purgeRepl.ReplaceKnown(escapedKeyTmpl, "")
+	conds := purgeRepl.ReplaceKnown(config.CacheKeyTemplate, "")
 	return c.Purge(cache, conds)
 }

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -90,7 +90,7 @@ func (suite *CacheEndpointTestSuite) TestListCacheKeys() {
 	result, err := ioutil.ReadAll(res.Body)
 	res.Body.Close()
 	suite.Assert().NoError(err)
-	suite.True(strings.Contains(string(result), "GET localhost/hello?"))
+	suite.True(strings.Contains(string(result), "GET localhost/hello"))
 
 }
 
@@ -108,7 +108,7 @@ func (suite *CacheEndpointTestSuite) TestShowCache() {
 	_, err = suite.caddyTester.Client.Do(r)
 	suite.Assert().NoError(err)
 	// create the cache first
-	url := fmt.Sprintf("http://localhost:7777/caches/%s", url.PathEscape("GET localhost/hello?"))
+	url := fmt.Sprintf("http://localhost:7777/caches/%s", url.PathEscape("GET localhost/hello"))
 
 	r, err = http.NewRequest("GET", url, nil)
 	suite.Assert().NoError(err)
@@ -134,7 +134,7 @@ func (suite *CacheEndpointTestSuite) TestPurgeCache() {
 			host:     "http://localhost:9898/",
 			uri:      "hello",
 			body:     []byte(`{"method": "GET", "host": "http://localhost", "uri": "hello"}`),
-			cacheKey: "GET localhost/hello?",
+			cacheKey: "GET localhost/hello",
 		},
 		{
 			host:     "http://localhost:9898/",
@@ -146,7 +146,7 @@ func (suite *CacheEndpointTestSuite) TestPurgeCache() {
 			host:     "http://localhost:9898/",
 			uri:      "hello",
 			body:     []byte(`{"host": "http://localhost/", "uri": "hello"}`), // host with trailing forward slash is also ok
-			cacheKey: "GET localhost/hello?",
+			cacheKey: "GET localhost/hello",
 		},
 	}
 

--- a/handler.go
+++ b/handler.go
@@ -70,9 +70,12 @@ func (h *Handler) respond(w http.ResponseWriter, entry *Entry, cacheStatus strin
 	h.addStatusHeaderIfConfigured(w, cacheStatus)
 	copyHeaders(entry.Response.snapHeader, w.Header())
 
+	// set the response code earlier to proxy the upstream response codes
+	// This avoids the cache to respond with 200 when the upstream sent a 302 (Redirect)
+	w.WriteHeader(entry.Response.Code)
+
 	// when the request method is head, we don't need ot perform write body
 	if entry.Request.Method == "HEAD" {
-		w.WriteHeader(entry.Response.Code)
 		return nil
 	}
 

--- a/readme.org
+++ b/readme.org
@@ -18,36 +18,36 @@
   Currently, this doesn't support =distributed cache= yet. It's still in plan.
 
 * Features
- 
+
 ** Multi storage backends support
    Now the following backends are supported.
-   
+
    - file
    - inmemory
    - redis
-   
+
    In the latter part, I will show the example Caddyfile to serve different type of proxy cache server.
-   
+
 ** Conditional rule to cache the upstream response
    - uri path matcher
    - http header matcher
 
 ** Set default cache's max age
    A default age for matched responses that do not have an explicit expiration.
-** Purge cache 
+** Purge cache
    There are exposed endpoints to purge cache. I implement it with admin apis endpoints. The following will show you how to purge cache
-   
+
 *** first you can list the current caches
-    
+
     Given that you specify the port 7777 to serve caddy admin, you can get the list of cache by the api below.
-    
+
     #+begin_src restclient
       GET http://example.com:7777/caches
     #+end_src
 
 *** purge the cache with http DELETE request
     It supports the regular expression.
-    
+
     #+begin_src restclient
       DELETE http://example.com:7777/caches/purge
       Content-Type: application/json
@@ -59,15 +59,15 @@
       }
     #+end_src
 ** Support cluster with consul
-   
-   NOTE: still under development and only the =memory= backend supports. 
-   
+
+   NOTE: still under development and only the =memory= backend supports.
+
    I've provided a simple example to mimic a cluster environment.
-   
+
    #+begin_src sh
      PROJECT_PATH=/app docker-compose --project-directory=./ -f example/distributed_cache/docker-compose.yaml up
    #+end_src
-   
+
 * How to build
 
   In development, go to the cmd folder and type the following commands.
@@ -75,23 +75,23 @@
   #+begin_src sh
     go build -ldflags="-w -s" -o caddy
   #+end_src
-  
+
   To build linux binary by this
-  #+begin_src 
+  #+begin_src
   GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o caddy
   #+end_src
-  
+
   Or you can use the [[https://github.com/caddyserver/xcaddy][xcaddy]] to build the executable file.
   Ensure you've install it by =go get -u github.com/caddyserver/xcaddy/cmd/xcaddy=
   #+begin_src sh
-    xcaddy build v2.0.0 --with github.com/sillygod/cdp-cache 
+    xcaddy build v2.0.0 --with github.com/sillygod/cdp-cache
   #+end_src
-  
+
   Xcaddy also provide a way to develop plugin locally.
   #+begin_src sh
     xcaddy run --config cmd/Caddyfile
   #+end_src
-  
+
   To remove unused dependencies
   #+begin_src sh
     go mod tidy
@@ -103,14 +103,14 @@
   #+begin_src sh
     caddy run --config [caddy file] --adapter caddyfile
   #+end_src
-  
-  Or if you are preferred to use the docker 
+
+  Or if you are preferred to use the docker
   #+begin_src sh
     docker run -it -p80:80 -p443:443 -v [the path of caddyfile]:/app/Caddyfile docker.pkg.github.com/sillygod/cdp-cache/caddy:latest
   #+end_src
 
 * Configuration
-  
+
   The following will list current support configs in the caddyfile.
 
 *** status_header
@@ -123,9 +123,9 @@
     The cache's expiration time.
 
 *** match_header
-    only the req's header match the condtions 
+    only the req's header match the condtions
     ex.
-    
+
     #+begin_quote
     match_header Content-Type image/jpg image/png "text/plain; charset=utf-8"
     #+end_quote
@@ -134,53 +134,53 @@
     The position where to save the file. Only applied when the =cache_type= is =file=.
 
 *** cache_key
-    The key of cache entry. The default value is ={http.request.method} {http.request.host}{http.request.uri.path}?{http.request.uri.query}=
+    The key of cache entry. The default value is ={http.request.method} {http.request.host}{http.request.uri}=
 
 *** cache_bucket_num
     The bucket number of the mod of cache_key's checksum. The default value is 256.
 
 *** cache_type
     Indicate to use which kind of cache's storage backend. Currently, there are two choices. One is =file= and the other is =in_memory=
-   
+
 *** cache_max_memory_size
 
     The max memory usage for in_memory backend.
-    
+
 *** distributed
-    
+
     Working in process. Currently, only support =consul= to establish the cluster of cache server node.
 
-    To see a example config, please refer [[file:example/distributed_cache/Caddyfile::health_check ":7777/health"][this]] 
-    
+    To see a example config, please refer [[file:example/distributed_cache/Caddyfile::health_check ":7777/health"][this]]
+
 **** service_name
      specify your service to be registered in the consul agent.
-   
+
 **** addr
      the address of the consul agent.
 
 **** health_check
      indicate the health_check endpoint which consul agent will use this endpoint to check the cache server is healthy
-     
-     
+
+
 ** Example configs
    You can go to the directory [[file:example/][example]]. It shows you each type of cache's configuration.
 
 * Benchmarks
-  
+
   Now, I just simply compares the performance between in-memory and disk.
-  
+
 ** Env
    Caddy run with the config file under directory =benchmark= and tests were run on the mac book pro (1.4 GHz Intel Core i5, 16 GB 2133 MHz LPDDR3)
 
 ** Test Result
 
    The following benchmark is analysized by =wrk -c 50 -d 30s --latency -t 4 http://localhost:9991/pg31674.txt= without log open. Before running this, ensure you provision the tests data by =bash benchmark/provision.sh=
-  
+
    |                         | req/s | latency (50% 90% 99%)     |
    | proxy + file cache      | 13853 | 3.29ms /  4.09ms / 5.26ms |
    | proxy + in memory cache | 20622 | 2.20ms /  3.03ms / 4.68ms |
 
 * Todo list
-  
+
   - [ ] distributed cache (in progress)
   - [ ] more optimization..


### PR DESCRIPTION
Close #33 

- Reply to the client with the correct response status code
- Use a better, more specific `defaultCacheKeyTemplate` to exact matches on resources that are redirected.
- The other changes are my VSCode editor removing white spaces
- Changes how the file backend store the files by using sha256 hashes based on the entry keyWithRespectVary() content. This way, we don't waste storage space by creating duplicated temporary files every time the caddy process is restarted.
- Implemented the Length() function for the file backend, since some browsers have grief when the Content-Length is set to 0 and abort the operation causing the http request to have an empty body
- Fix some tests