### PR TITLE
Fixed header "Content-Length: 0"

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -317,7 +317,9 @@ func (e *Entry) writePublicResponse(w http.ResponseWriter) error {
 
 	if length == "" {
 		contentLength := strconv.Itoa(e.Response.body.Length())
-		w.Header().Set("Content-Length", contentLength)
+		if contentLength != "0" {
+			w.Header().Set("Content-Length", contentLength)
+		}
 	}
 
 	// wow, we should write the header before calling this function


### PR DESCRIPTION
The header "Content-Length: 0" causes problems in Firefox and curl (curl: (92) HTTP/2 stream 1 was not closed cleanly: PROTOCOL_ERROR (err 1) or Firefox doesn't download the content).

The "backends.Backend.Length()" function can only return 0, so maybe it can be removed completely.