### PR TITLE
Support HTTP POST requests

### DIFF
--- a/caddyfile.go
+++ b/caddyfile.go
@@ -39,6 +39,7 @@ var (
 	defaultLockTimeout            = time.Duration(5) * time.Minute
 	defaultMaxAge                 = time.Duration(5) * time.Minute
 	defaultPath                   = "/tmp/caddy_cache"
+	defaultMatchMethods           = []string{"GET", "HEAD"}
 	defaultCacheType              = file
 	defaultcacheBucketsNum        = 256
 	defaultCacheMaxMemorySize     = GB // default is 1 GB
@@ -55,6 +56,7 @@ const (
 	keyPath                   = "path"
 	keyMatchHeader            = "match_header"
 	keyMatchPath              = "match_path"
+	keyMatchMethod            = "match_methods"
 	keyCacheKey               = "cache_key"
 	keyCacheBucketsNum        = "cache_bucket_num"
 	keyCacheMaxMemorySize     = "cache_max_memory_size"
@@ -80,6 +82,7 @@ type Config struct {
 	LockTimeout            time.Duration            `json:"lock_timeout,omitempty"`
 	RuleMatchersRaws       []RuleMatcherRawWithType `json:"rule_matcher_raws,omitempty"`
 	RuleMatchers           []RuleMatcher            `json:"-"`
+	MatchMethods           []string                 `json:"match_methods,omitempty"`
 	CacheBucketsNum        int                      `json:"cache_buckets_num,omitempty"`
 	CacheMaxMemorySize     int                      `json:"cache_max_memory_size,omitempty"`
 	Path                   string                   `json:"path,omitempty"`
@@ -94,6 +97,7 @@ func getDefaultConfig() *Config {
 		LockTimeout:            defaultLockTimeout,
 		RuleMatchersRaws:       []RuleMatcherRawWithType{},
 		RuleMatchers:           []RuleMatcher{},
+		MatchMethods:           defaultMatchMethods,
 		CacheBucketsNum:        defaultcacheBucketsNum,
 		CacheMaxMemorySize:     defaultCacheMaxMemorySize,
 		Path:                   defaultPath,
@@ -210,6 +214,12 @@ func (h *Handler) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 					Type: MatcherTypePath,
 					Data: data,
 				})
+
+			case keyMatchMethod:
+				if len(args) < 2 {
+					return d.Err("Invalid usage of match_method in cache config.")
+				}
+				config.MatchMethods = append(config.MatchMethods, args...)
 
 			case keyCacheKey:
 				if len(args) != 1 {

--- a/handler.go
+++ b/handler.go
@@ -329,7 +329,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 
 	}(h, start)
 
-	if !shouldUseCache(r) {
+	if !shouldUseCache(r, h.Config) {
 		h.addStatusHeaderIfConfigured(w, cacheBypass)
 		return next.ServeHTTP(w, r)
 	}

--- a/handler.go
+++ b/handler.go
@@ -93,7 +93,7 @@ func popOrNil(h *Handler, errChan chan error) (err error) {
 
 }
 
-func (h *Handler) fetchUpstream(req *http.Request, next caddyhttp.Handler) (*Entry, error) {
+func (h *Handler) fetchUpstream(req *http.Request, next caddyhttp.Handler, key string) (*Entry, error) {
 	// Create a new empty response
 	response := NewResponse()
 
@@ -131,7 +131,7 @@ func (h *Handler) fetchUpstream(req *http.Request, next caddyhttp.Handler) (*Ent
 	response.WaitHeaders()
 
 	// Create a new CacheEntry
-	return NewEntry(getKey(h.Config.CacheKeyTemplate, req), req, response, h.Config), popOrNil(h, errChan)
+	return NewEntry(key, req, response, h.Config), popOrNil(h, errChan)
 }
 
 // CaddyModule returns the Caddy module information
@@ -359,7 +359,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 	if h.Distributed != nil {
 		// new an entry without fetching the upstream
 		response := NewResponse()
-		entry := NewEntry(getKey(h.Config.CacheKeyTemplate, r), r, response, h.Config)
+		entry := NewEntry(key, r, response, h.Config)
 		err := entry.setBackend(r.Context(), h.Config)
 		if err != nil {
 			return caddyhttp.Error(http.StatusInternalServerError, err)
@@ -393,7 +393,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request, next caddyht
 	// It should be fetched from upstream and save it in cache
 
 	t := time.Now()
-	entry, err := h.fetchUpstream(r, next)
+	entry, err := h.fetchUpstream(r, next, key)
 	upstreamDuration = time.Since(t)
 
 	if err != nil {

--- a/readme.org
+++ b/readme.org
@@ -122,6 +122,8 @@
 *** match_methods
     By default, only =GET= and =POST= methods are cached. If you would like to cache other methods as well you can configure here which methods should be cached, e.g.: =GET HEAD POST=.
 
+    To be able to distinguish different POST requests, it is advisable to include the body hash in the cache key, e.g.: ={http.request.method} {http.request.host}{http.request.uri.path}?{http.request.uri.query} {http.request.contentlength} {http.request.bodyhash}=
+
 *** default_max_age
     The cache's expiration time.
 

--- a/readme.org
+++ b/readme.org
@@ -119,6 +119,9 @@
 *** match_path
     Only the request's path match the condition will be cached. Ex. =/= means all request need to be cached because all request's path must start with =/=
 
+*** match_methods
+    By default, only =GET= and =POST= methods are cached. If you would like to cache other methods as well you can configure here which methods should be cached, e.g.: =GET HEAD POST=.
+
 *** default_max_age
     The cache's expiration time.
 

--- a/response.go
+++ b/response.go
@@ -144,10 +144,16 @@ func (r *Response) WriteHeader(code int) {
 	r.headersChan <- struct{}{}
 }
 
-func shouldUseCache(req *http.Request) bool {
+func shouldUseCache(req *http.Request, config *Config) bool {
 
-	if req.Method != "GET" && req.Method != "HEAD" {
-		// Only cache Get and head request
+	matchMethod := false
+	for _, method := range config.MatchMethods {
+		if method == req.Method {
+			matchMethod = true
+			break
+		}
+	}
+	if !matchMethod {
 		return false
 	}
 


### PR DESCRIPTION
We at [Gitpod](https://www.gitpod.io/) would like to use this great Caddy plugin for caching HTTP POST requests. Unfortunately, only GET and HEAD requests are supported yet. This PR adds the possibility to configure this plugin to cache HTTP POST requests as well.

This PR provides 2 commits:
- The first commit allows to configure which HTTP methods are cached.
- The second commit adds two new variables to the cache key template: `http.request.contentlength` and `http.request.bodyhash`.

For caching POST requests it's important to distinguish requests with different body contents. The second commit adds `http.request.contentlength` and `http.request.bodyhash`. For the body hash it's important that the cache key is calculated before the body has been read (before it's empty). Therefore the key is passed to `fetchUpstream`.

We would be happy if you would accept this change and thus expand the possibilities of the use of this plugin. Please let me know if you need anything else from me.