### PR TITLE
allow to answer with stale cache entry in case of upstream server error

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -216,7 +216,7 @@ func (suite *HTTPCacheTestSuite) SetupSuite() {
 
 func (suite *HTTPCacheTestSuite) TestGetNonExistEntry() {
 	req := makeRequest("/", http.Header{})
-	entry, exists := suite.cache.Get("abc", req)
+	entry, exists := suite.cache.Get("abc", req, false)
 	suite.Nil(entry)
 	suite.False(exists)
 }
@@ -238,9 +238,9 @@ func (suite *HTTPCacheTestSuite) TestGetExistEntry() {
 	req := makeRequest("/", http.Header{})
 	res := makeResponse(200, http.Header{})
 	entry := NewEntry("hello", req, res, suite.config)
-	suite.cache.Put(req, entry)
+	suite.cache.Put(req, entry, suite.config)
 
-	prevEntry, exists := suite.cache.Get("hello", req)
+	prevEntry, exists := suite.cache.Get("hello", req, false)
 	suite.Equal(prevEntry, entry)
 	suite.True(exists)
 }
@@ -251,7 +251,7 @@ func (suite *HTTPCacheTestSuite) TestCleanEntry() {
 	key := "friday"
 
 	entry := NewEntry(key, req, res, suite.config)
-	suite.cache.Put(req, entry)
+	suite.cache.Put(req, entry, suite.config)
 
 	keyInKeys := false
 	keys := suite.cache.Keys()

--- a/endpoint.go
+++ b/endpoint.go
@@ -146,7 +146,7 @@ func (c cachePurge) handleShowCache(w http.ResponseWriter, r *http.Request) erro
 	key := helper.TrimBy(r.URL.Path, "/", 2)
 	cache := getHandlerCache()
 
-	entry, exists := cache.Get(key, r)
+	entry, exists := cache.Get(key, r, false)
 	if exists {
 		err = entry.WriteBodyTo(w)
 	}

--- a/readme.org
+++ b/readme.org
@@ -122,6 +122,11 @@
 *** default_max_age
     The cache's expiration time.
 
+*** stale_max_age
+    The duration that a cache entry is kept in the cache, even though it has already expired. The default duration is =0=.
+
+    If this duration is > 0 and the upstream server answers with an HTTP status code >= 500 (server error) this plugin checks whether there is still an expired (stale) entry from a previous, successful call in the cache. In that case, this stale entry is used to answer instead of the 5xx response.
+
 *** match_header
     only the req's header match the condtions
     ex.


### PR DESCRIPTION
At [Gitpod](https://www.gitpod.io/), we would like to use this great plugin to use cached entries in case the upstream server answers with an HTTP status code >= 500 (server error). This is similar to the `proxy_cache_use_stale` option of nginx (see [nginx docs](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_use_stale)).

This PR adds a new config option `stale_max_age` with a default of `0`. If this value is > 0, this duration is added to the expiration time. That means entries are kept in the cache for this time after they have already expired. When the upstream server answers with an HTTP status code >= 500 (server error) this plugin checks whether there is still an expired (stale) entry from a previous, successful call in the cache. In that case, this stale entry is used to answer instead of the 5xx response. Otherwise, the expired entries are ignored.

We would be happy if you would accept this change and thus expand the possibilities of the use of this plugin. Please let me know if you need anything else from me.